### PR TITLE
Upgrade to Java 17, latest dependencies and fix warnings and typos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /.project
 /application.log
 /target/
+/.idea

--- a/pom.xml
+++ b/pom.xml
@@ -68,8 +68,8 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>17</maven.compiler.source>
-		<maven.compiler.target>17</maven.compiler.target>
+		<maven.compiler.source>11</maven.compiler.source>
+		<maven.compiler.target>11</maven.compiler.target>
 		<spring.version>5.3.34</spring.version>
 		<slf4j.version>2.0.16</slf4j.version>
 		<aspectj.version>1.9.22.1</aspectj.version>
@@ -80,7 +80,7 @@
 		<plugins>
 			<!-- <plugin> <groupId>org.codehaus.mojo</groupId> <artifactId>aspectj-maven-plugin</artifactId> <version>1.7</version> <executions> <execution> <goals> <goal>compile</goal> </goals> </execution> </executions> 
 				<configuration> <source>${maven.compiler.source}</source> <target>${maven.compiler.target}</target> <complianceLevel>1.6</complianceLevel> <showWeaveInfo>true</showWeaveInfo> </configuration> </plugin> -->
-			<plugin><!-- needed for site pluging to accept scp urls -->
+			<plugin><!-- needed for site plugin to accept scp urls -->
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-site-plugin</artifactId>
 				<version>3.20.0</version>
@@ -219,7 +219,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-project-info-reports-plugin</artifactId>
-				<version>3.7.0</version>
+				<version>3.8.0</version>
 				<configuration>
 					<dependencyDetailsEnabled>false</dependencyDetailsEnabled>
 					<dependencyLocationsEnabled>false</dependencyLocationsEnabled>
@@ -229,8 +229,8 @@
 						<reports>
 							<!-- <report>index</report> -->
 							<report>summary</report>
-							<report>issue-tracking</report>
-							<report>project-team</report>
+							<report>issue-management</report>
+							<report>team</report>
 							<report>dependencies</report>
 							<report>scm</report>
 							<report>modules</report>
@@ -250,18 +250,10 @@
 				</configuration>
 				<version>2.19.1</version>
 			</plugin>
-			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>findbugs-maven-plugin</artifactId>
-				<version>3.0.5</version>
-				<configuration>
-					<xmlOutput>true</xmlOutput>
-				</configuration>
-			</plugin>
-			<plugin>
+<!-- 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-pmd-plugin</artifactId>
-				<version>3.25.0</version>
+				<version>3.26.0</version>
 				<configuration>
 					<targetJdk>${maven.compiler.source}</targetJdk>
 					<sourceEncoding>${project.build.sourceEncoding}</sourceEncoding>
@@ -272,7 +264,7 @@
 					<linkXref>true</linkXref>
 					<failOnViolation>false</failOnViolation>
 				</configuration>
-			</plugin>
+			</plugin> -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jxr-plugin</artifactId>
@@ -282,18 +274,6 @@
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>taglist-maven-plugin</artifactId>
 				<version>3.2.1</version>
-			</plugin>
-			<!--coberura plugin makes the tests -->
-			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>cobertura-maven-plugin</artifactId>
-				<version>2.7</version>
-				<configuration>
-					<formats>
-						<format>html</format>
-						<!-- needed only for CI servers such as jenkins <format>xml</format> -->
-					</formats>
-				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>net.sf.aspect4log</groupId>
 	<artifactId>aspect4log</artifactId>
-	<version>1.0.8</version>
+	<version>2.0.0</version>
 	<inceptionYear>2013</inceptionYear>
 	<name>${project.artifactId}</name>
 	<description>Provides aspect for logging via slf4j by placing @Log annotation on classes and methods.</description>
@@ -68,11 +68,11 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>1.6</maven.compiler.source>
-		<maven.compiler.target>1.6</maven.compiler.target>
-		<spring.version>4.2.5.RELEASE</spring.version>
-		<slf4j.version>1.7.18</slf4j.version>
-		<aspectj.version>1.8.8</aspectj.version>
+		<maven.compiler.source>17</maven.compiler.source>
+		<maven.compiler.target>17</maven.compiler.target>
+		<spring.version>5.3.34</spring.version>
+		<slf4j.version>2.0.16</slf4j.version>
+		<aspectj.version>1.9.22.1</aspectj.version>
 		<maven-pmd-plugin.configLocation>${project.basedir}/pmd.xml</maven-pmd-plugin.configLocation>
 	</properties>
 
@@ -83,7 +83,7 @@
 			<plugin><!-- needed for site pluging to accept scp urls -->
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-site-plugin</artifactId>
-				<version>3.4</version>
+				<version>3.20.0</version>
 				<dependencies>
 					<dependency>
 						<groupId>org.apache.maven.wagon</groupId>
@@ -146,11 +146,25 @@
 			<artifactId>commons-lang3</artifactId>
 			<version>3.4</version>
 		</dependency>
+		<!-- https://mvnrepository.com/artifact/jakarta.xml.bind/jakarta.xml.bind-api -->
+		<dependency>
+			<groupId>jakarta.xml.bind</groupId>
+			<artifactId>jakarta.xml.bind-api</artifactId>
+			<version>4.0.2</version>
+		</dependency>
+		<!-- https://mvnrepository.com/artifact/org.glassfish.jaxb/jaxb-runtime -->
+		<dependency>
+			<groupId>org.glassfish.jaxb</groupId>
+			<artifactId>jaxb-runtime</artifactId>
+			<version>4.0.5</version>
+			<scope>test</scope>
+		</dependency>
+
 
 		<dependency>
 			<groupId>commons-beanutils</groupId>
 			<artifactId>commons-beanutils</artifactId>
-			<version>1.9.2</version>
+			<version>1.9.4</version>
 			<exclusions>
 				<exclusion>
 					<artifactId>commons-logging</artifactId>
@@ -168,7 +182,7 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.12</version>
+			<version>4.13.1</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -205,7 +219,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-project-info-reports-plugin</artifactId>
-				<version>2.8.1</version>
+				<version>3.7.0</version>
 				<configuration>
 					<dependencyDetailsEnabled>false</dependencyDetailsEnabled>
 					<dependencyLocationsEnabled>false</dependencyLocationsEnabled>
@@ -239,7 +253,7 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>findbugs-maven-plugin</artifactId>
-				<version>3.0.3</version>
+				<version>3.0.5</version>
 				<configuration>
 					<xmlOutput>true</xmlOutput>
 				</configuration>
@@ -247,7 +261,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-pmd-plugin</artifactId>
-				<version>3.6</version>
+				<version>3.25.0</version>
 				<configuration>
 					<targetJdk>${maven.compiler.source}</targetJdk>
 					<sourceEncoding>${project.build.sourceEncoding}</sourceEncoding>
@@ -262,12 +276,12 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jxr-plugin</artifactId>
-				<version>2.5</version>
+				<version>3.5.0</version>
 			</plugin>
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>taglist-maven-plugin</artifactId>
-				<version>2.4</version>
+				<version>3.2.1</version>
 			</plugin>
 			<!--coberura plugin makes the tests -->
 			<plugin>
@@ -284,7 +298,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-changes-plugin</artifactId>
-				<version>2.11</version>
+				<version>2.12.1</version>
 				<!-- <inherited>false</inherited> -->
 				<reportSets>
 					<reportSet>

--- a/src/main/java/net/sf/aspect4log/aspect/LogAspect.java
+++ b/src/main/java/net/sf/aspect4log/aspect/LogAspect.java
@@ -60,13 +60,13 @@ public class LogAspect {
 	}
 
 	/*
-	 * it is marked static, because if there is more than one instance of LogApsect we must have one ident system per thread
+	 * it is marked static, because if there is more than one instance of LogAspect we must have one ident system per thread
 	 */
-	private static final ThreadLocal<Integer> thraedLocalIndent = new ThreadLocal<Integer>();
+	private static final ThreadLocal<Integer> threadLocalIndent = new ThreadLocal<>();
 
 	// @Around("execution(!@Log *(@Log *).*(..)) && @target(log)")
 	@Around("(execution(!@net.sf.aspect4log.Log *(@net.sf.aspect4log.Log *).*(..))|| execution(!@net.sf.aspect4log.Log *.new(..)))  && @within(log)")
-	public Object logNotAnnotatedMethondsInAnnotatedClasses(ProceedingJoinPoint pjp, Log log) throws Throwable {
+	public Object logNotAnnotatedMethodsInAnnotatedClasses(ProceedingJoinPoint pjp, Log log) throws Throwable {
 		return log(pjp, log);
 	}
 
@@ -76,8 +76,8 @@ public class LogAspect {
 		return log(pjp, log);
 	}
 
-	public static final Integer getThreadLocalIdent() {
-		return thraedLocalIndent.get() == null ? Integer.valueOf(0) : thraedLocalIndent.get();
+	public static Integer getThreadLocalIdent() {
+		return threadLocalIndent.get() == null ? Integer.valueOf(0) : threadLocalIndent.get();
 	}
 
 	private Object log(ProceedingJoinPoint pjp, Log log) throws Throwable {
@@ -145,20 +145,20 @@ public class LogAspect {
 
 	private void increaseIndent(Log log) {
 		if (log.indent()) {
-			if (thraedLocalIndent.get() == null) {
-				thraedLocalIndent.set(Integer.valueOf(0));
-			} else if (thraedLocalIndent.get() != null) {
-				thraedLocalIndent.set(Integer.valueOf(thraedLocalIndent.get() + 1));
+			if (threadLocalIndent.get() == null) {
+				threadLocalIndent.set(0);
+			} else if (threadLocalIndent.get() != null) {
+				threadLocalIndent.set(threadLocalIndent.get() + 1);
 			}
 		}
 	}
 
 	private void decreaseIndent(Log log) {
 		if (log.indent()) {
-			if (thraedLocalIndent.get().equals(Integer.valueOf(0))) {
-				thraedLocalIndent.remove();
+			if (threadLocalIndent.get().equals(0)) {
+				threadLocalIndent.remove();
 			} else {
-				thraedLocalIndent.set(Integer.valueOf(thraedLocalIndent.get() - 1));
+				threadLocalIndent.set(threadLocalIndent.get() - 1);
 			}
 		}
 	}

--- a/src/main/java/net/sf/aspect4log/conf/LogFormatConfiguration.java
+++ b/src/main/java/net/sf/aspect4log/conf/LogFormatConfiguration.java
@@ -20,13 +20,13 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAnyElement;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlTransient;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAnyElement;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlTransient;
 
 import net.sf.aspect4log.text.CustomisableMessageBuilderFactory;
 import net.sf.aspect4log.text.MessageBuilderFactory;
@@ -57,28 +57,29 @@ public class LogFormatConfiguration {
 	}
 
 	@XmlElement
-	public void setMessageBuilderFactoryConfiguration(MessageBuilderFactoryConfiguration messageBuilderFactoryConfiguration) throws InstantiationException, IllegalAccessException, InvocationTargetException, DOMException {
-		messageBuilderFactory = messageBuilderFactoryConfiguration.getClazz().newInstance();
+	public void setMessageBuilderFactoryConfiguration(MessageBuilderFactoryConfiguration messageBuilderFactoryConfiguration) throws InstantiationException, IllegalAccessException, InvocationTargetException, DOMException, NoSuchMethodException {
+		messageBuilderFactory = messageBuilderFactoryConfiguration.getClazz().getConstructor().newInstance();
 		for (Element element : messageBuilderFactoryConfiguration.getProperties()) {
 			BeanUtils.setProperty(messageBuilderFactory, element.getTagName(), element.getTextContent());
 		}
 	}
+
+	@XmlAccessorType(XmlAccessType.FIELD)
+	public static class MessageBuilderFactoryConfiguration {
+		@XmlAnyElement
+		private final List<Element> properties = new ArrayList<Element>();
+
+		@XmlAttribute(name = "class")
+		private Class<? extends MessageBuilderFactory> clazz;
+
+		protected List<Element> getProperties() {
+			return properties;
+		}
+
+		protected Class<? extends MessageBuilderFactory> getClazz() {
+			return clazz;
+		}
+
+	}
 }
 
-@XmlAccessorType(XmlAccessType.FIELD)
-class MessageBuilderFactoryConfiguration {
-	@XmlAnyElement
-	private final List<Element> properties = new ArrayList<Element>();
-
-	@XmlAttribute(name = "class")
-	private Class<? extends MessageBuilderFactory> clazz;
-
-	protected List<Element> getProperties() {
-		return properties;
-	}
-
-	protected Class<? extends MessageBuilderFactory> getClazz() {
-		return clazz;
-	}
-
-}

--- a/src/main/java/net/sf/aspect4log/conf/LogFormatConfigurationException.java
+++ b/src/main/java/net/sf/aspect4log/conf/LogFormatConfigurationException.java
@@ -16,7 +16,6 @@
  */
 package net.sf.aspect4log.conf;
 
-import java.io.Serial;
 
 /**
  * This exception is thrown in case  aspect4log.xml or aspect4log-test.xml contains errors.  
@@ -26,7 +25,6 @@ import java.io.Serial;
  */
 public class LogFormatConfigurationException extends RuntimeException {
 
-	@Serial
 	private static final long serialVersionUID = -3397749350256923573L;
 
 	public LogFormatConfigurationException() {

--- a/src/main/java/net/sf/aspect4log/conf/LogFormatConfigurationException.java
+++ b/src/main/java/net/sf/aspect4log/conf/LogFormatConfigurationException.java
@@ -15,6 +15,9 @@
   
  */
 package net.sf.aspect4log.conf;
+
+import java.io.Serial;
+
 /**
  * This exception is thrown in case  aspect4log.xml or aspect4log-test.xml contains errors.  
  * 
@@ -23,6 +26,7 @@ package net.sf.aspect4log.conf;
  */
 public class LogFormatConfigurationException extends RuntimeException {
 
+	@Serial
 	private static final long serialVersionUID = -3397749350256923573L;
 
 	public LogFormatConfigurationException() {

--- a/src/main/java/net/sf/aspect4log/conf/LogFormatConfigurationUtils.java
+++ b/src/main/java/net/sf/aspect4log/conf/LogFormatConfigurationUtils.java
@@ -18,12 +18,11 @@ package net.sf.aspect4log.conf;
 
 import java.net.URL;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.Unmarshaller;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.Unmarshaller;
 
 /**
  * This class is responsible for reading aspect4log configuration.
- *  
  * It tries to load configuration from aspect4log-test.xml,
  * if it does not exit it tries to read configuration from aspect4log.xml, 
  * if it does not exit it loads default configuration.

--- a/src/main/java/net/sf/aspect4log/text/CustomisableMessageBuilderFactory.java
+++ b/src/main/java/net/sf/aspect4log/text/CustomisableMessageBuilderFactory.java
@@ -43,13 +43,13 @@ public class CustomisableMessageBuilderFactory implements MessageBuilderFactory 
 
 	/**
 	 * 
-	 * @return specifies if indent should be used for methods called inside marked method. The default value is true.
+	 * Specifies if indent should be used for methods called inside marked method. The default value is true.
 	 */
 
 	private boolean useIndent = true;
 
 	/**
-	 * @return a java.lang.String that represents text of Indent. The default value is 1 tab symbol.
+	 * Represents text of Indent. The default value is 1 tab symbol.
 	 */
 
 	private String indentText = "\t";
@@ -147,7 +147,7 @@ public class CustomisableMessageBuilderFactory implements MessageBuilderFactory 
 		private final Log log;
 		private final Object[] args;
 
-		protected SimpleMdcMessageBuilder(Log log, Object[] args) {
+		private SimpleMdcMessageBuilder(Log log, Object[] args) {
 			this.log = log;
 			this.args = (Object[])args.clone();
 		}
@@ -267,7 +267,7 @@ public class CustomisableMessageBuilderFactory implements MessageBuilderFactory 
 		}
 
 		protected void buildIndent(StringBuilder stringBuilder) {
-			for (int i = 0; i < LogAspect.getThreadLocalIdent().intValue(); i++) {
+			for (int i = 0; i < LogAspect.getThreadLocalIdent(); i++) {
 				stringBuilder.append(indentText);
 			}
 		}

--- a/src/test/java/net/sf/aspect4log/text/LogFormatterTest.java
+++ b/src/test/java/net/sf/aspect4log/text/LogFormatterTest.java
@@ -3,19 +3,19 @@ package net.sf.aspect4log.text;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class LogFormmatterTest {
+public class LogFormatterTest {
 
 	@Test
 	public void isToStringOverriden() {
-		Assert.assertFalse(new LogFormatter().isToStringOverriden(new Object().getClass()));
-		Assert.assertFalse(new LogFormatter().isToStringOverriden(new Object[] { 1 }.getClass()));
-		Assert.assertTrue(new LogFormatter().isToStringOverriden(new String("s").getClass()));
-		Assert.assertTrue(new LogFormatter().isToStringOverriden(new Integer(1).getClass()));
+		Assert.assertFalse(new LogFormatter().isToStringOverriden(Object.class));
+		Assert.assertFalse(new LogFormatter().isToStringOverriden(Object[].class));
+		Assert.assertTrue(new LogFormatter().isToStringOverriden(String.class));
+		Assert.assertTrue(new LogFormatter().isToStringOverriden(Integer.class));
 	}
 	
 	@Test
 	public void testSubstitute(){
-		Integer i = 5;
+		int i = 5;
 		String s = "s";
 		int[] ii = { 1, 2 };
 		Object[] args = { i, s, ii };

--- a/src/test/java/org/foo/TestFooService.java
+++ b/src/test/java/org/foo/TestFooService.java
@@ -54,13 +54,13 @@ public class TestFooService {
 	public void testOneIsFoo() {
 		Assert.assertTrue(fooService.isAtLeastOneFoo("boo", "foo",new Object()));
 		
-		List<String> list = new ArrayList<String>();
+		List<String> list = new ArrayList<>();
 		list.add("l1");
 		list.add("l2");
 		
-		Map<Object,Object> map = new HashMap<Object,Object>();
+		Map<Object,Object> map = new HashMap<>();
 		map.put("key1", "value1");
-		map.put(new Integer(1), new Thread());
+		map.put(1, new Object());
 		Assert.assertFalse(fooService.isAtLeastOneFoo(new ToStringBreaker(),"boo", new Object(),list,map));
 	}
 


### PR DESCRIPTION
I don't think this is still maintained, but as I was using it in an old project of mine that I'm updating to Java 17, I made the changes. 